### PR TITLE
Move run from npm packager to command to avoid spawn npm run ENOENT e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ serverless client build --packager yarn
 
 #### `--command`, `-c` <!-- omit in toc -->
 
-The command that will build the client. Default value is `build`
+The command that will build the client. Default value is `build` for yarn and `run build` for npm
 
 ##### Examples <!-- omit in toc -->
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,352 +1,384 @@
-const childProcess = require('cross-spawn');
+const childProcess = require("cross-spawn");
 
-const ServerlessClientBuildPlugin = require('../index');
-const constants = require('../constants');
+const ServerlessClientBuildPlugin = require("../index");
+const constants = require("../constants");
 
-jest.mock('cross-spawn', () => ({
-	spawn: jest.fn(() => ({
-		stdout: {
-			on: jest.fn(),
-		},
-		stderr: {
-			on: jest.fn(),
-		},
-		on: jest.fn(),
-	})),
+jest.mock("cross-spawn", () => ({
+  spawn: jest.fn(() => ({
+    stdout: {
+      on: jest.fn()
+    },
+    stderr: {
+      on: jest.fn()
+    },
+    on: jest.fn()
+  }))
 }));
 
-describe('ServerlessClientBuildPlugin tests', () => {
-	const env = process.env;
-	const options = {
-		packager: 'yarn',
-		command: 'build',
-	};
+describe("ServerlessClientBuildPlugin tests", () => {
+  const env = process.env;
+  const options = {
+    packager: "yarn",
+    command: "build"
+  };
 
-	beforeEach(() => {
-		jest.clearAllMocks();
-		process.env = JSON.parse(JSON.stringify(env));
-	});
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = JSON.parse(JSON.stringify(env));
+  });
 
-	it('should create the object', () => {
-		const serverless = {
-			cli: {
-				log: jest.fn(),
-			},
-		};
-		const plugin = new ServerlessClientBuildPlugin(serverless, options);
+  it("should create the object", () => {
+    const serverless = {
+      cli: {
+        log: jest.fn()
+      }
+    };
+    const plugin = new ServerlessClientBuildPlugin(serverless, options);
 
-		expect(plugin.serverless).toEqual(serverless);
-		expect(plugin.options).toEqual(options);
-		expect(plugin.commands).toEqual({
-			client: {
-				usage: 'A plugin used to build front end applications',
-				lifecycleEvents: ['build'],
-				commands: {
-					build: {
-						usage: 'Build the client',
-						lifecycleEvents: ['build'],
-						options: {
-							packager: {
-								usage: 'The packager that will be used to build the client',
-								shortcut: 'p',
-							},
-							command: {
-								usage: 'The command that will be used to build the client',
-								shortcut: 'c',
-							},
-						},
-					},
-				},
-			},
-		});
-		expect(plugin.hooks).toEqual({
-			'before:client:build:build': expect.any(Function),
-			'client:build:build': expect.any(Function),
-			'after:client:build:build': expect.any(Function),
-		});
-	});
+    expect(plugin.serverless).toEqual(serverless);
+    expect(plugin.options).toEqual(options);
+    expect(plugin.commands).toEqual({
+      client: {
+        usage: "A plugin used to build front end applications",
+        lifecycleEvents: ["build"],
+        commands: {
+          build: {
+            usage: "Build the client",
+            lifecycleEvents: ["build"],
+            options: {
+              packager: {
+                usage: "The packager that will be used to build the client",
+                shortcut: "p"
+              },
+              command: {
+                usage: "The command that will be used to build the client",
+                shortcut: "c"
+              }
+            }
+          }
+        }
+      }
+    });
+    expect(plugin.hooks).toEqual({
+      "before:client:build:build": expect.any(Function),
+      "client:build:build": expect.any(Function),
+      "after:client:build:build": expect.any(Function)
+    });
+  });
 
-	it('should log message after build is completed', () => {
-		const serverless = {
-			cli: {
-				log: jest.fn(),
-			},
-		};
-		const plugin = new ServerlessClientBuildPlugin(serverless, options);
-		plugin.afterClientBuild();
+  it("should log message after build is completed", () => {
+    const serverless = {
+      cli: {
+        log: jest.fn()
+      }
+    };
+    const plugin = new ServerlessClientBuildPlugin(serverless, options);
+    plugin.afterClientBuild();
 
-		expect(plugin.serverless.cli.log('Successfully built the client'));
-	});
+    expect(plugin.serverless.cli.log("Successfully built the client"));
+  });
 
-	describe('beforeClientBuild tests', () => {
-		it('should skip processing environment variables', () => {
-			const serverless = {
-				cli: {
-					log: jest.fn(),
-				},
-				service: {
-					provider: {},
-				},
-			};
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin.beforeClientBuild();
+  describe("beforeClientBuild tests", () => {
+    it("should skip processing environment variables", () => {
+      const serverless = {
+        cli: {
+          log: jest.fn()
+        },
+        service: {
+          provider: {}
+        }
+      };
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin.beforeClientBuild();
 
-			expect(plugin.serverless.cli.log).toHaveBeenCalledWith(
-				'No environment variables detected. Skipping step...'
-			);
-			expect(process.env).toEqual(env);
-		});
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(
+        "No environment variables detected. Skipping step..."
+      );
+      expect(process.env).toEqual(env);
+    });
 
-		it.each([
-			['should process empty list of environment variables', {}],
-			[
-				'should process on environment variable',
-				{
-					HELLO_WORLD: 'hello world',
-				},
-			],
-			[
-				'should process multiple environment variables',
-				{
-					HELLO_WORLD: 'hello world',
-					FOO_BAR: 'foo bar',
-				},
-			],
-		])('%s', (message, environment) => {
-			const serverless = {
-				cli: {
-					log: jest.fn(),
-				},
-				service: {
-					provider: {
-						environment,
-					},
-				},
-			};
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin.beforeClientBuild();
+    it.each([
+      ["should process empty list of environment variables", {}],
+      [
+        "should process on environment variable",
+        {
+          HELLO_WORLD: "hello world"
+        }
+      ],
+      [
+        "should process multiple environment variables",
+        {
+          HELLO_WORLD: "hello world",
+          FOO_BAR: "foo bar"
+        }
+      ]
+    ])("%s", (message, environment) => {
+      const serverless = {
+        cli: {
+          log: jest.fn()
+        },
+        service: {
+          provider: {
+            environment
+          }
+        }
+      };
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin.beforeClientBuild();
 
-			expect(plugin.serverless.cli.log.mock.calls).toEqual(
-				[['Setting the environment variables']].concat(
-					Object.keys(environment).map(variable => [`Setting ${variable} to ${environment[variable]}`])
-				)
-			);
-			expect(process.env).toEqual(expect.objectContaining(environment));
-		});
-	});
+      expect(plugin.serverless.cli.log.mock.calls).toEqual(
+        [["Setting the environment variables"]].concat(
+          Object.keys(environment).map(variable => [
+            `Setting ${variable} to ${environment[variable]}`
+          ])
+        )
+      );
+      expect(process.env).toEqual(expect.objectContaining(environment));
+    });
+  });
 
-	describe('clientBuild tests', () => {
-		const resolve = jest.fn();
-		const reject = jest.fn();
-		const stdout = jest.fn((event, f) => f('some stdout'));
-		const stderr = jest.fn((event, f) => f('some stderr'));
-		const error = 'error';
-		const serverless = {
-			cli: {
-				log: jest.fn(),
-			},
-			classes: {
-				Error: jest.fn(err => new Error(err)),
-			},
-		};
+  describe("clientBuild tests", () => {
+    const resolve = jest.fn();
+    const reject = jest.fn();
+    const stdout = jest.fn((event, f) => f("some stdout"));
+    const stderr = jest.fn((event, f) => f("some stderr"));
+    const error = "error";
+    const serverless = {
+      cli: {
+        log: jest.fn()
+      },
+      classes: {
+        Error: jest.fn(err => new Error(err))
+      }
+    };
 
-		beforeEach(() => {
-			jest.clearAllMocks();
-		});
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
 
-		it('should start to build the client', () => {
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin.clientBuild();
+    it("should start to build the client", () => {
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin.clientBuild();
 
-			expect(plugin.serverless.cli.log).toHaveBeenCalledWith('Building the client');
-		});
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(
+        "Building the client"
+      );
+    });
 
-		it('should throw if packager is invalid', () => {
-			const on = jest.fn((event, f) => f(0));
-			childProcess.spawn.mockImplementation(() => ({
-				stdout: {
-					on: stdout,
-				},
-				stderr: {
-					on: stderr,
-				},
-				on,
-			}));
+    it("should throw if packager is invalid", () => {
+      const on = jest.fn((event, f) => f(0));
+      childProcess.spawn.mockImplementation(() => ({
+        stdout: {
+          on: stdout
+        },
+        stderr: {
+          on: stderr
+        },
+        on
+      }));
 
-			const plugin = new ServerlessClientBuildPlugin(serverless, {
-				packager: 'hello',
-				command: 'build',
-			});
-			plugin._onStdout = jest.fn();
-			plugin._onStderr = jest.fn();
-			plugin._onError = jest.fn();
-			plugin._clientBuild(resolve, reject);
+      const plugin = new ServerlessClientBuildPlugin(serverless, {
+        packager: "hello",
+        command: "build"
+      });
+      plugin._onStdout = jest.fn();
+      plugin._onStderr = jest.fn();
+      plugin._onError = jest.fn();
+      plugin._clientBuild(resolve, reject);
 
-			expect(childProcess.spawn).not.toHaveBeenCalled();
-			expect(stdout).not.toHaveBeenCalled();
-			expect(stderr).not.toHaveBeenCalled();
-			expect(on).not.toHaveBeenCalled();
-			expect(resolve).not.toHaveBeenCalled();
-			expect(reject).toHaveBeenCalledWith(
-				new Error(`Invalid packager. Expected one of ${Object.keys(constants.packagers)}`)
-			);
-		});
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+      expect(stdout).not.toHaveBeenCalled();
+      expect(stderr).not.toHaveBeenCalled();
+      expect(on).not.toHaveBeenCalled();
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalledWith(
+        new Error(
+          `Invalid packager. Expected one of ${Object.keys(
+            constants.packagers
+          )}`
+        )
+      );
+    });
 
-		it('should build with default packager and default command', () => {
-			const on = jest.fn((event, f) => f(0));
-			childProcess.spawn.mockImplementation(() => ({
-				stdout: {
-					on: stdout,
-				},
-				stderr: {
-					on: stderr,
-				},
-				on,
-			}));
+    it("should build with default packager and default command", () => {
+      const on = jest.fn((event, f) => f(0));
+      childProcess.spawn.mockImplementation(() => ({
+        stdout: {
+          on: stdout
+        },
+        stderr: {
+          on: stderr
+        },
+        on
+      }));
 
-			const plugin = new ServerlessClientBuildPlugin(serverless, {});
-			plugin._onStdout = jest.fn();
-			plugin._onStderr = jest.fn();
-			plugin._onError = jest.fn();
-			plugin._clientBuild(resolve, reject);
+      const plugin = new ServerlessClientBuildPlugin(serverless, {});
+      plugin._onStdout = jest.fn();
+      plugin._onStderr = jest.fn();
+      plugin._onError = jest.fn();
+      plugin._clientBuild(resolve, reject);
 
-			expect(childProcess.spawn).toHaveBeenCalledWith('yarn', ['build']);
-			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
-			expect(resolve).toHaveBeenCalled();
-			expect(reject).not.toHaveBeenCalled();
-		});
+      expect(childProcess.spawn).toHaveBeenCalledWith("yarn", ["build"]);
+      expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(on.mock.calls).toEqual([
+        ["error", expect.any(Function)],
+        ["close", expect.any(Function)]
+      ]);
+      expect(resolve).toHaveBeenCalled();
+      expect(reject).not.toHaveBeenCalled();
+    });
 
-		it.each(Object.keys(constants.packagers))('should build with %s packager and custom command', packager => {
-			const on = jest.fn((event, f) => f(0));
-			childProcess.spawn.mockImplementation(() => ({
-				stdout: {
-					on: stdout,
-				},
-				stderr: {
-					on: stderr,
-				},
-				on,
-			}));
+    it.each(Object.keys(constants.packagers))(
+      "should build with %s packager and custom command",
+      packager => {
+        const on = jest.fn((event, f) => f(0));
+        childProcess.spawn.mockImplementation(() => ({
+          stdout: {
+            on: stdout
+          },
+          stderr: {
+            on: stderr
+          },
+          on
+        }));
 
-			const plugin = new ServerlessClientBuildPlugin(serverless, {
-				packager,
-				command: 'build',
-			});
-			plugin._onStdout = jest.fn();
-			plugin._onStderr = jest.fn();
-			plugin._onError = jest.fn();
-			plugin._clientBuild(resolve, reject);
+        const plugin = new ServerlessClientBuildPlugin(serverless, {
+          packager,
+          command: "build"
+        });
+        plugin._onStdout = jest.fn();
+        plugin._onStderr = jest.fn();
+        plugin._onError = jest.fn();
+        plugin._clientBuild(resolve, reject);
 
-			expect(childProcess.spawn).toHaveBeenCalledWith(constants.packagers[packager], ['build']);
-			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
-			expect(resolve).toHaveBeenCalled();
-			expect(reject).not.toHaveBeenCalled();
-		});
+        expect(childProcess.spawn).toHaveBeenCalledWith(
+          constants.packagers[packager],
+          ["build"]
+        );
+        expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
+        expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
+        expect(on.mock.calls).toEqual([
+          ["error", expect.any(Function)],
+          ["close", expect.any(Function)]
+        ]);
+        expect(resolve).toHaveBeenCalled();
+        expect(reject).not.toHaveBeenCalled();
+      }
+    );
 
-		it.each(Object.keys(constants.packagers))('should build with %s packager and default command', packager => {
-			const on = jest.fn((event, f) => f(0));
-			childProcess.spawn.mockImplementation(() => ({
-				stdout: {
-					on: stdout,
-				},
-				stderr: {
-					on: stderr,
-				},
-				on,
-			}));
+    it.each(Object.keys(constants.packagers))(
+      "should build with %s packager and default command",
+      packager => {
+        const on = jest.fn((event, f) => f(0));
+        childProcess.spawn.mockImplementation(() => ({
+          stdout: {
+            on: stdout
+          },
+          stderr: {
+            on: stderr
+          },
+          on
+        }));
 
-			const plugin = new ServerlessClientBuildPlugin(serverless, {
-				packager,
-			});
-			plugin._onStdout = jest.fn();
-			plugin._onStderr = jest.fn();
-			plugin._onError = jest.fn();
-			plugin._clientBuild(resolve, reject);
+        const plugin = new ServerlessClientBuildPlugin(serverless, {
+          packager
+        });
+        plugin._onStdout = jest.fn();
+        plugin._onStderr = jest.fn();
+        plugin._onError = jest.fn();
+        plugin._clientBuild(resolve, reject);
 
-			expect(childProcess.spawn).toHaveBeenCalledWith(
-				constants.packagers[packager],
-				constants.defaults.command[packager].split(' ')
-			);
-			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
-			expect(resolve).toHaveBeenCalled();
-			expect(reject).not.toHaveBeenCalled();
-		});
+        expect(childProcess.spawn).toHaveBeenCalledWith(
+          constants.packagers[packager],
+          constants.defaults.command[packager].split(" ")
+        );
+        expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
+        expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
+        expect(on.mock.calls).toEqual([
+          ["error", expect.any(Function)],
+          ["close", expect.any(Function)]
+        ]);
+        expect(resolve).toHaveBeenCalled();
+        expect(reject).not.toHaveBeenCalled();
+      }
+    );
 
-		it('should resolve with exit code 0', () => {
-			const on = jest.fn((event, f) => f(0));
-			childProcess.spawn.mockImplementation(() => ({
-				stdout: {
-					on: stdout,
-				},
-				stderr: {
-					on: stderr,
-				},
-				on,
-			}));
+    it("should resolve with exit code 0", () => {
+      const on = jest.fn((event, f) => f(0));
+      childProcess.spawn.mockImplementation(() => ({
+        stdout: {
+          on: stdout
+        },
+        stderr: {
+          on: stderr
+        },
+        on
+      }));
 
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin._onStdout = jest.fn();
-			plugin._onStderr = jest.fn();
-			plugin._onError = jest.fn();
-			plugin._clientBuild(resolve, reject);
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin._onStdout = jest.fn();
+      plugin._onStderr = jest.fn();
+      plugin._onError = jest.fn();
+      plugin._clientBuild(resolve, reject);
 
-			expect(childProcess.spawn).toHaveBeenCalledWith('yarn', ['build']);
-			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
-			expect(resolve).toHaveBeenCalled();
-			expect(reject).not.toHaveBeenCalled();
-		});
+      expect(childProcess.spawn).toHaveBeenCalledWith("yarn", ["build"]);
+      expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(on.mock.calls).toEqual([
+        ["error", expect.any(Function)],
+        ["close", expect.any(Function)]
+      ]);
+      expect(resolve).toHaveBeenCalled();
+      expect(reject).not.toHaveBeenCalled();
+    });
 
-		it('should resolve with exit code 1', () => {
-			const on = jest.fn((event, f) => f(1));
-			childProcess.spawn.mockImplementation(() => ({
-				stdout: {
-					on: stdout,
-				},
-				stderr: {
-					on: stderr,
-				},
-				on,
-			}));
+    it("should resolve with exit code 1", () => {
+      const on = jest.fn((event, f) => f(1));
+      childProcess.spawn.mockImplementation(() => ({
+        stdout: {
+          on: stdout
+        },
+        stderr: {
+          on: stderr
+        },
+        on
+      }));
 
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin._onStdout = jest.fn();
-			plugin._onStderr = jest.fn();
-			plugin._onError = jest.fn();
-			plugin._clientBuild(resolve, reject);
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin._onStdout = jest.fn();
+      plugin._onStderr = jest.fn();
+      plugin._onError = jest.fn();
+      plugin._clientBuild(resolve, reject);
 
-			expect(childProcess.spawn).toHaveBeenCalledWith('yarn', ['build']);
-			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
-			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
-			expect(resolve).not.toHaveBeenCalled();
-			expect(reject).toHaveBeenCalled();
-		});
+      expect(childProcess.spawn).toHaveBeenCalledWith("yarn", ["build"]);
+      expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
+      expect(on.mock.calls).toEqual([
+        ["error", expect.any(Function)],
+        ["close", expect.any(Function)]
+      ]);
+      expect(resolve).not.toHaveBeenCalled();
+      expect(reject).toHaveBeenCalled();
+    });
 
-		it('should log the stdout', () => {
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin._onStdout(new Buffer(' hello '));
-			expect(serverless.cli.log).toHaveBeenCalledWith('hello');
-		});
+    it("should log the stdout", () => {
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin._onStdout(new Buffer(" hello "));
+      expect(serverless.cli.log).toHaveBeenCalledWith("hello");
+    });
 
-		it('should log the stderr', () => {
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin._onStderr(new Buffer(` ${error} `));
-			expect(plugin.error).toEqual(new Error(error));
-			expect(serverless.cli.log).toHaveBeenCalledWith(error);
-		});
+    it("should log the stderr", () => {
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin._onStderr(new Buffer(` ${error} `));
+      expect(plugin.error).toEqual(new Error(error));
+      expect(serverless.cli.log).toHaveBeenCalledWith(error);
+    });
 
-		it('should set the error', () => {
-			const plugin = new ServerlessClientBuildPlugin(serverless, options);
-			plugin._onError(error);
-			expect(plugin.error).toEqual(new Error(error));
-		});
-	});
+    it("should set the error", () => {
+      const plugin = new ServerlessClientBuildPlugin(serverless, options);
+      plugin._onError(error);
+      expect(plugin.error).toEqual(new Error(error));
+    });
+  });
 });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,320 +1,352 @@
-const childProcess = require("cross-spawn");
+const childProcess = require('cross-spawn');
 
-const ServerlessClientBuildPlugin = require("../index");
-const constants = require("../constants");
+const ServerlessClientBuildPlugin = require('../index');
+const constants = require('../constants');
 
-jest.mock("cross-spawn", () => ({
-  spawn: jest.fn(() => ({
-    stdout: {
-      on: jest.fn()
-    },
-    stderr: {
-      on: jest.fn()
-    },
-    on: jest.fn()
-  }))
+jest.mock('cross-spawn', () => ({
+	spawn: jest.fn(() => ({
+		stdout: {
+			on: jest.fn(),
+		},
+		stderr: {
+			on: jest.fn(),
+		},
+		on: jest.fn(),
+	})),
 }));
 
-describe("ServerlessClientBuildPlugin tests", () => {
-  const env = process.env;
-  const options = {
-    packager: "yarn",
-    command: "build"
-  };
+describe('ServerlessClientBuildPlugin tests', () => {
+	const env = process.env;
+	const options = {
+		packager: 'yarn',
+		command: 'build',
+	};
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    process.env = JSON.parse(JSON.stringify(env));
-  });
+	beforeEach(() => {
+		jest.clearAllMocks();
+		process.env = JSON.parse(JSON.stringify(env));
+	});
 
-  it("should create the object", () => {
-    const serverless = {
-      cli: {
-        log: jest.fn()
-      }
-    };
-    const plugin = new ServerlessClientBuildPlugin(serverless, options);
+	it('should create the object', () => {
+		const serverless = {
+			cli: {
+				log: jest.fn(),
+			},
+		};
+		const plugin = new ServerlessClientBuildPlugin(serverless, options);
 
-    expect(plugin.serverless).toEqual(serverless);
-    expect(plugin.options).toEqual(options);
-    expect(plugin.commands).toEqual({
-      client: {
-        usage: "A plugin used to build front end applications",
-        lifecycleEvents: ["build"],
-        commands: {
-          build: {
-            usage: "Build the client",
-            lifecycleEvents: ["build"],
-            options: {
-              packager: {
-                usage: "The packager that will be used to build the client",
-                shortcut: "p",
-                default: "yarn"
-              },
-              command: {
-                usage: "The command that will be used to build the client",
-                shortcut: "c",
-                default: "build"
-              }
-            }
-          }
-        }
-      }
-    });
-    expect(plugin.hooks).toEqual({
-      "before:client:build:build": expect.any(Function),
-      "client:build:build": expect.any(Function),
-      "after:client:build:build": expect.any(Function)
-    });
-  });
+		expect(plugin.serverless).toEqual(serverless);
+		expect(plugin.options).toEqual(options);
+		expect(plugin.commands).toEqual({
+			client: {
+				usage: 'A plugin used to build front end applications',
+				lifecycleEvents: ['build'],
+				commands: {
+					build: {
+						usage: 'Build the client',
+						lifecycleEvents: ['build'],
+						options: {
+							packager: {
+								usage: 'The packager that will be used to build the client',
+								shortcut: 'p',
+							},
+							command: {
+								usage: 'The command that will be used to build the client',
+								shortcut: 'c',
+							},
+						},
+					},
+				},
+			},
+		});
+		expect(plugin.hooks).toEqual({
+			'before:client:build:build': expect.any(Function),
+			'client:build:build': expect.any(Function),
+			'after:client:build:build': expect.any(Function),
+		});
+	});
 
-  it("should log message after build is completed", () => {
-    const serverless = {
-      cli: {
-        log: jest.fn()
-      }
-    };
-    const plugin = new ServerlessClientBuildPlugin(serverless, options);
-    plugin.afterClientBuild();
+	it('should log message after build is completed', () => {
+		const serverless = {
+			cli: {
+				log: jest.fn(),
+			},
+		};
+		const plugin = new ServerlessClientBuildPlugin(serverless, options);
+		plugin.afterClientBuild();
 
-    expect(plugin.serverless.cli.log("Successfully built the client"));
-  });
+		expect(plugin.serverless.cli.log('Successfully built the client'));
+	});
 
-  describe("beforeClientBuild tests", () => {
-    it("should skip processing environment variables", () => {
-      const serverless = {
-        cli: {
-          log: jest.fn()
-        },
-        service: {
-          provider: {}
-        }
-      };
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin.beforeClientBuild();
+	describe('beforeClientBuild tests', () => {
+		it('should skip processing environment variables', () => {
+			const serverless = {
+				cli: {
+					log: jest.fn(),
+				},
+				service: {
+					provider: {},
+				},
+			};
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin.beforeClientBuild();
 
-      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(
-        "No environment variables detected. Skipping step..."
-      );
-      expect(process.env).toEqual(env);
-    });
+			expect(plugin.serverless.cli.log).toHaveBeenCalledWith(
+				'No environment variables detected. Skipping step...'
+			);
+			expect(process.env).toEqual(env);
+		});
 
-    it.each([
-      ["should process empty list of environment variables", {}],
-      [
-        "should process on environment variable",
-        {
-          HELLO_WORLD: "hello world"
-        }
-      ],
-      [
-        "should process multiple environment variables",
-        {
-          HELLO_WORLD: "hello world",
-          FOO_BAR: "foo bar"
-        }
-      ]
-    ])("%s", (message, environment) => {
-      const serverless = {
-        cli: {
-          log: jest.fn()
-        },
-        service: {
-          provider: {
-            environment
-          }
-        }
-      };
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin.beforeClientBuild();
+		it.each([
+			['should process empty list of environment variables', {}],
+			[
+				'should process on environment variable',
+				{
+					HELLO_WORLD: 'hello world',
+				},
+			],
+			[
+				'should process multiple environment variables',
+				{
+					HELLO_WORLD: 'hello world',
+					FOO_BAR: 'foo bar',
+				},
+			],
+		])('%s', (message, environment) => {
+			const serverless = {
+				cli: {
+					log: jest.fn(),
+				},
+				service: {
+					provider: {
+						environment,
+					},
+				},
+			};
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin.beforeClientBuild();
 
-      expect(plugin.serverless.cli.log.mock.calls).toEqual(
-        [["Setting the environment variables"]].concat(
-          Object.keys(environment).map(variable => [
-            `Setting ${variable} to ${environment[variable]}`
-          ])
-        )
-      );
-      expect(process.env).toEqual(expect.objectContaining(environment));
-    });
-  });
+			expect(plugin.serverless.cli.log.mock.calls).toEqual(
+				[['Setting the environment variables']].concat(
+					Object.keys(environment).map(variable => [`Setting ${variable} to ${environment[variable]}`])
+				)
+			);
+			expect(process.env).toEqual(expect.objectContaining(environment));
+		});
+	});
 
-  describe("clientBuild tests", () => {
-    const resolve = jest.fn();
-    const reject = jest.fn();
-    const stdout = jest.fn((event, f) => f("some stdout"));
-    const stderr = jest.fn((event, f) => f("some stderr"));
-    const error = "error";
-    const serverless = {
-      cli: {
-        log: jest.fn()
-      },
-      classes: {
-        Error: jest.fn(err => new Error(err))
-      }
-    };
+	describe('clientBuild tests', () => {
+		const resolve = jest.fn();
+		const reject = jest.fn();
+		const stdout = jest.fn((event, f) => f('some stdout'));
+		const stderr = jest.fn((event, f) => f('some stderr'));
+		const error = 'error';
+		const serverless = {
+			cli: {
+				log: jest.fn(),
+			},
+			classes: {
+				Error: jest.fn(err => new Error(err)),
+			},
+		};
 
-    beforeEach(() => {
-      jest.clearAllMocks();
-    });
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
 
-    it("should start to build the client", () => {
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin.clientBuild();
+		it('should start to build the client', () => {
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin.clientBuild();
 
-      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(
-        "Building the client"
-      );
-    });
+			expect(plugin.serverless.cli.log).toHaveBeenCalledWith('Building the client');
+		});
 
-    it("should throw if packager is invalid", () => {
-      const on = jest.fn((event, f) => f(0));
-      childProcess.spawn.mockImplementation(() => ({
-        stdout: {
-          on: stdout
-        },
-        stderr: {
-          on: stderr
-        },
-        on
-      }));
+		it('should throw if packager is invalid', () => {
+			const on = jest.fn((event, f) => f(0));
+			childProcess.spawn.mockImplementation(() => ({
+				stdout: {
+					on: stdout,
+				},
+				stderr: {
+					on: stderr,
+				},
+				on,
+			}));
 
-      const plugin = new ServerlessClientBuildPlugin(serverless, {
-        packager: "hello",
-        command: "build"
-      });
-      plugin._onStdout = jest.fn();
-      plugin._onStderr = jest.fn();
-      plugin._onError = jest.fn();
-      plugin._clientBuild(resolve, reject);
+			const plugin = new ServerlessClientBuildPlugin(serverless, {
+				packager: 'hello',
+				command: 'build',
+			});
+			plugin._onStdout = jest.fn();
+			plugin._onStderr = jest.fn();
+			plugin._onError = jest.fn();
+			plugin._clientBuild(resolve, reject);
 
-      expect(childProcess.spawn).not.toHaveBeenCalled();
-      expect(stdout).not.toHaveBeenCalled();
-      expect(stderr).not.toHaveBeenCalled();
-      expect(on).not.toHaveBeenCalled();
-      expect(resolve).not.toHaveBeenCalled();
-      expect(reject).toHaveBeenCalledWith(
-        new Error(
-          `Invalid packager. Expected one of ${Object.keys(
-            constants.packagers
-          )}`
-        )
-      );
-    });
+			expect(childProcess.spawn).not.toHaveBeenCalled();
+			expect(stdout).not.toHaveBeenCalled();
+			expect(stderr).not.toHaveBeenCalled();
+			expect(on).not.toHaveBeenCalled();
+			expect(resolve).not.toHaveBeenCalled();
+			expect(reject).toHaveBeenCalledWith(
+				new Error(`Invalid packager. Expected one of ${Object.keys(constants.packagers)}`)
+			);
+		});
 
-    it.each([Object.keys(constants.packagers)])(
-      "should build with %s packager",
-      packager => {
-        const on = jest.fn((event, f) => f(0));
-        childProcess.spawn.mockImplementation(() => ({
-          stdout: {
-            on: stdout
-          },
-          stderr: {
-            on: stderr
-          },
-          on
-        }));
+		it('should build with default packager and default command', () => {
+			const on = jest.fn((event, f) => f(0));
+			childProcess.spawn.mockImplementation(() => ({
+				stdout: {
+					on: stdout,
+				},
+				stderr: {
+					on: stderr,
+				},
+				on,
+			}));
 
-        const plugin = new ServerlessClientBuildPlugin(serverless, {
-          packager,
-          command: "build"
-        });
-        plugin._onStdout = jest.fn();
-        plugin._onStderr = jest.fn();
-        plugin._onError = jest.fn();
-        plugin._clientBuild(resolve, reject);
+			const plugin = new ServerlessClientBuildPlugin(serverless, {});
+			plugin._onStdout = jest.fn();
+			plugin._onStderr = jest.fn();
+			plugin._onError = jest.fn();
+			plugin._clientBuild(resolve, reject);
 
-        expect(childProcess.spawn).toHaveBeenCalledWith(
-          constants.packagers[packager],
-          ["build"]
-        );
-        expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
-        expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
-        expect(on.mock.calls).toEqual([
-          ["error", expect.any(Function)],
-          ["close", expect.any(Function)]
-        ]);
-        expect(resolve).toHaveBeenCalled();
-        expect(reject).not.toHaveBeenCalled();
-      }
-    );
+			expect(childProcess.spawn).toHaveBeenCalledWith('yarn', ['build']);
+			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
+			expect(resolve).toHaveBeenCalled();
+			expect(reject).not.toHaveBeenCalled();
+		});
 
-    it("should resolve with exist code 0", () => {
-      const on = jest.fn((event, f) => f(0));
-      childProcess.spawn.mockImplementation(() => ({
-        stdout: {
-          on: stdout
-        },
-        stderr: {
-          on: stderr
-        },
-        on
-      }));
+		it.each(Object.keys(constants.packagers))('should build with %s packager and custom command', packager => {
+			const on = jest.fn((event, f) => f(0));
+			childProcess.spawn.mockImplementation(() => ({
+				stdout: {
+					on: stdout,
+				},
+				stderr: {
+					on: stderr,
+				},
+				on,
+			}));
 
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin._onStdout = jest.fn();
-      plugin._onStderr = jest.fn();
-      plugin._onError = jest.fn();
-      plugin._clientBuild(resolve, reject);
+			const plugin = new ServerlessClientBuildPlugin(serverless, {
+				packager,
+				command: 'build',
+			});
+			plugin._onStdout = jest.fn();
+			plugin._onStderr = jest.fn();
+			plugin._onError = jest.fn();
+			plugin._clientBuild(resolve, reject);
 
-      expect(childProcess.spawn).toHaveBeenCalledWith("yarn", ["build"]);
-      expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
-      expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
-      expect(on.mock.calls).toEqual([
-        ["error", expect.any(Function)],
-        ["close", expect.any(Function)]
-      ]);
-      expect(resolve).toHaveBeenCalled();
-      expect(reject).not.toHaveBeenCalled();
-    });
+			expect(childProcess.spawn).toHaveBeenCalledWith(constants.packagers[packager], ['build']);
+			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
+			expect(resolve).toHaveBeenCalled();
+			expect(reject).not.toHaveBeenCalled();
+		});
 
-    it("should resolve with exist code 1", () => {
-      const on = jest.fn((event, f) => f(1));
-      childProcess.spawn.mockImplementation(() => ({
-        stdout: {
-          on: stdout
-        },
-        stderr: {
-          on: stderr
-        },
-        on
-      }));
+		it.each(Object.keys(constants.packagers))('should build with %s packager and default command', packager => {
+			const on = jest.fn((event, f) => f(0));
+			childProcess.spawn.mockImplementation(() => ({
+				stdout: {
+					on: stdout,
+				},
+				stderr: {
+					on: stderr,
+				},
+				on,
+			}));
 
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin._onStdout = jest.fn();
-      plugin._onStderr = jest.fn();
-      plugin._onError = jest.fn();
-      plugin._clientBuild(resolve, reject);
+			const plugin = new ServerlessClientBuildPlugin(serverless, {
+				packager,
+			});
+			plugin._onStdout = jest.fn();
+			plugin._onStderr = jest.fn();
+			plugin._onError = jest.fn();
+			plugin._clientBuild(resolve, reject);
 
-      expect(childProcess.spawn).toHaveBeenCalledWith("yarn", ["build"]);
-      expect(stdout).toHaveBeenCalledWith("data", expect.any(Function));
-      expect(stderr).toHaveBeenCalledWith("data", expect.any(Function));
-      expect(on.mock.calls).toEqual([
-        ["error", expect.any(Function)],
-        ["close", expect.any(Function)]
-      ]);
-      expect(resolve).not.toHaveBeenCalled();
-      expect(reject).toHaveBeenCalled();
-    });
+			expect(childProcess.spawn).toHaveBeenCalledWith(
+				constants.packagers[packager],
+				constants.defaults.command[packager].split(' ')
+			);
+			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
+			expect(resolve).toHaveBeenCalled();
+			expect(reject).not.toHaveBeenCalled();
+		});
 
-    it("should log the stdout", () => {
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin._onStdout(new Buffer(" hello "));
-      expect(serverless.cli.log).toHaveBeenCalledWith("hello");
-    });
+		it('should resolve with exit code 0', () => {
+			const on = jest.fn((event, f) => f(0));
+			childProcess.spawn.mockImplementation(() => ({
+				stdout: {
+					on: stdout,
+				},
+				stderr: {
+					on: stderr,
+				},
+				on,
+			}));
 
-    it("should log the stderr", () => {
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin._onStderr(new Buffer(` ${error} `));
-      expect(plugin.error).toEqual(new Error(error));
-      expect(serverless.cli.log).toHaveBeenCalledWith(error);
-    });
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin._onStdout = jest.fn();
+			plugin._onStderr = jest.fn();
+			plugin._onError = jest.fn();
+			plugin._clientBuild(resolve, reject);
 
-    it("should set the error", () => {
-      const plugin = new ServerlessClientBuildPlugin(serverless, options);
-      plugin._onError(error);
-      expect(plugin.error).toEqual(new Error(error));
-    });
-  });
+			expect(childProcess.spawn).toHaveBeenCalledWith('yarn', ['build']);
+			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
+			expect(resolve).toHaveBeenCalled();
+			expect(reject).not.toHaveBeenCalled();
+		});
+
+		it('should resolve with exit code 1', () => {
+			const on = jest.fn((event, f) => f(1));
+			childProcess.spawn.mockImplementation(() => ({
+				stdout: {
+					on: stdout,
+				},
+				stderr: {
+					on: stderr,
+				},
+				on,
+			}));
+
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin._onStdout = jest.fn();
+			plugin._onStderr = jest.fn();
+			plugin._onError = jest.fn();
+			plugin._clientBuild(resolve, reject);
+
+			expect(childProcess.spawn).toHaveBeenCalledWith('yarn', ['build']);
+			expect(stdout).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(stderr).toHaveBeenCalledWith('data', expect.any(Function));
+			expect(on.mock.calls).toEqual([['error', expect.any(Function)], ['close', expect.any(Function)]]);
+			expect(resolve).not.toHaveBeenCalled();
+			expect(reject).toHaveBeenCalled();
+		});
+
+		it('should log the stdout', () => {
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin._onStdout(new Buffer(' hello '));
+			expect(serverless.cli.log).toHaveBeenCalledWith('hello');
+		});
+
+		it('should log the stderr', () => {
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin._onStderr(new Buffer(` ${error} `));
+			expect(plugin.error).toEqual(new Error(error));
+			expect(serverless.cli.log).toHaveBeenCalledWith(error);
+		});
+
+		it('should set the error', () => {
+			const plugin = new ServerlessClientBuildPlugin(serverless, options);
+			plugin._onError(error);
+			expect(plugin.error).toEqual(new Error(error));
+		});
+	});
 });

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,12 @@
 module.exports.packagers = {
   yarn: "yarn",
-  npm: "npm run"
+  npm: "npm"
+};
+
+module.exports.defaults = {
+  packager: "yarn",
+  command: {
+    yarn: "build",
+    npm: "run build"
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,13 +18,11 @@ class ServerlessClientBuildPlugin {
             options: {
               packager: {
                 usage: "The packager that will be used to build the client",
-                shortcut: "p",
-                default: "yarn"
+                shortcut: "p"
               },
               command: {
                 usage: "The command that will be used to build the client",
-                shortcut: "c",
-                default: "build"
+                shortcut: "c"
               }
             }
           }
@@ -68,7 +66,10 @@ class ServerlessClientBuildPlugin {
 
   _clientBuild(resolve, reject) {
     const packagers = Object.keys(constants.packagers);
-    if (!packagers.includes(this.options.packager)) {
+    const packager = this.options.packager || constants.defaults.packager;
+    const command = this.options.command || constants.defaults.command[packager];
+
+    if (!packagers.includes(packager)) {
       return reject(
         new this.serverless.classes.Error(
           `Invalid packager. Expected one of ${packagers}`
@@ -77,8 +78,8 @@ class ServerlessClientBuildPlugin {
     }
 
     const build = spawn(
-      constants.packagers[this.options.packager],
-      this.options.command.split(" ")
+      constants.packagers[packager],
+      command.split(" ")
     );
 
     build.stdout.on("data", this._onStdout.bind(this));


### PR DESCRIPTION
Move run from npm packager to command to avoid spawn npm run ENOENT errors.

Required shift of defaults to constants file to allow for differentiation between yarn default and npm default