### PR TITLE
Issue 5: Add --verbose option to control when to log environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ The directory that will be used to run the packager. Default value is the curren
 $ serverless client build --packager npm --command "run build" --cwd client
 ```
 
+#### `--verbose`, `-v` <!-- omit in toc -->
+
+Flag that determines if we should print the environment variables to the console. Default value is `false`
+
+##### Example <!-- omit in toc -->
+
+```
+$ serverless client build --verbose
+```
+
 ### Configuration
 
 #### Options
@@ -93,6 +103,7 @@ custom:
     packager: npm
     command: run build
     cwd: client
+    verbose: true
 ```
 
 #### Environment variables

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -19,7 +19,8 @@ describe("ServerlessClientBuildPlugin tests", () => {
   const env = process.env;
   const options = {
     packager: "yarn",
-    command: "build"
+    command: "build",
+    verbose: true
   };
 
   beforeEach(() => {
@@ -57,6 +58,11 @@ describe("ServerlessClientBuildPlugin tests", () => {
               cwd: {
                 usage: "The directory that will be used to run the packager",
                 shortcut: "d"
+              },
+              verbose: {
+                usage:
+                  "Setting this command prints the environment variables in the console",
+                shortcut: "v"
               }
             }
           }
@@ -214,6 +220,36 @@ describe("ServerlessClientBuildPlugin tests", () => {
         expect(process.env).toEqual(expect.objectContaining(expectedResult));
       }
     );
+
+    it("should not log the environment variables", () => {
+      const environment = {
+        HELLO_WORLD: "hello world"
+      };
+      const serverless = {
+        cli: {
+          log: jest.fn()
+        },
+        service: {
+          provider: {
+            environment
+          },
+          custom: {
+            buildClient: {
+              environment: {}
+            }
+          }
+        }
+      };
+      const plugin = new ServerlessClientBuildPlugin(
+        serverless,
+        Object.assign({}, options, { verbose: false })
+      );
+      plugin.beforeClientBuild();
+
+      expect(plugin.serverless.cli.log.mock.calls).toEqual([
+        ["Setting the environment variables"]
+      ]);
+    });
   });
 
   describe("clientBuild tests", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,11 @@ class ServerlessClientBuildPlugin {
               cwd: {
                 usage: "The directory that will be used to run the packager",
                 shortcut: "d"
+              },
+              verbose: {
+                usage:
+                  "Setting this command prints the environment variables in the console",
+                shortcut: "v"
               }
             }
           }
@@ -52,12 +57,17 @@ class ServerlessClientBuildPlugin {
         provider: { environment: providerEnvironment = {} }
       }
     } = this.serverless;
-    const { environment: customEnvironment = {} } = this.configuration;
+    const { verbose: verboseOption } = this.options;
+    const {
+      environment: customEnvironment = {},
+      verbose: verboseConfiguration
+    } = this.configuration;
     const environment = Object.assign(
       {},
       providerEnvironment,
       customEnvironment
     );
+    const verbose = verboseOption || verboseConfiguration || false;
 
     if (!Object.keys(environment).length) {
       return this.serverless.cli.log(
@@ -66,9 +76,11 @@ class ServerlessClientBuildPlugin {
     }
 
     Object.keys(environment).forEach(variable => {
-      this.serverless.cli.log(
-        `Setting ${variable} to ${environment[variable]}`
-      );
+      if (verbose) {
+        this.serverless.cli.log(
+          `Setting ${variable} to ${environment[variable]}`
+        );
+      }
       process.env[variable] = environment[variable];
     });
   }


### PR DESCRIPTION
Added a `--verbose` option. After this change, but we will *not* log the environment variables unless this options is set

Closes #8 