### PR TITLE
Fixes issue with custom settings file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,8 @@ const constants = require("./constants");
 class ServerlessClientBuildPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
-    const {
-      service: { custom: { buildClient: configuration = {} } = {} } = {}
-    } = this.serverless;
-    this.configuration = configuration;
     this.options = options;
+    this.configuration = {};
 
     this.commands = {
       client: {
@@ -52,12 +49,14 @@ class ServerlessClientBuildPlugin {
 
   beforeClientBuild() {
     this.serverless.cli.log("Setting the environment variables");
+    const { verbose: verboseOption } = this.options;
     const {
       service: {
-        provider: { environment: providerEnvironment = {} }
-      }
+        custom: { buildClient: configuration = {} },
+        provider: { environment: providerEnvironment }
+      } = {}
     } = this.serverless;
-    const { verbose: verboseOption } = this.options;
+    this.configuration = configuration;
     const {
       environment: customEnvironment = {},
       verbose: verboseConfiguration


### PR DESCRIPTION
When the buildClient variables are contained in a custom settings file,
then the custom variables are not yet available in the plugin constructor.
Presumably, the serverless modules first initializes the plugin and only
then parses the files referenced in the config file.

This fix moves the setting of the configuration variable to the "beforeClientBuild" hook.