### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,20 +19,24 @@ class ServerlessClientBuildPlugin {
             options: {
               packager: {
                 usage: "The packager that will be used to build the client",
-                shortcut: "p"
+                shortcut: "p",
+                type: "string"
               },
               command: {
                 usage: "The command that will be used to build the client",
-                shortcut: "c"
+                shortcut: "c",
+                type: "string"
               },
               cwd: {
                 usage: "The directory that will be used to run the packager",
-                shortcut: "d"
+                shortcut: "d",
+                type: "string"
               },
               verbose: {
                 usage:
                   "Setting this command prints the environment variables in the console",
-                shortcut: "v"
+                shortcut: "v",
+                type: "boolean"
               }
             }
           }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessClientBuildPlugin for "packager", "command", "cwd", "verbose"
```