### PR TITLE
Add support for pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The command that will build the client. Default value is `build` for yarn and `r
 ```
 $ serverless client build --packager yarn --command build
 $ serverless client build --packager npm --command "run build"
+$ serverless client build --packager pnpm --command "run build"
 ```
 
 #### `--cwd`, `-d` <!-- omit in toc -->

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,12 +1,14 @@
 module.exports.packagers = {
   yarn: "yarn",
-  npm: "npm"
+  npm: "npm",
+  pnpm: "pnpm"
 };
 
 module.exports.defaults = {
   packager: "yarn",
   command: {
     yarn: "build",
-    npm: "run build"
+    npm: "run build",
+    pnpm: "run build"
   }
 };


### PR DESCRIPTION
## Add pnpm as supported packager for client builds

This PR adds support for **pnpm** as a build packager in `serverless-build-client`.

### Changes
- Added `pnpm` to the list of supported packagers.
- Added a default build command for pnpm (`pnpm run build`), consistent with the existing npm behavior.

### Rationale
`pnpm` is widely used as a drop-in alternative to npm/yarn and is fully compatible with the current build execution model of this plugin.
The existing implementation already resolves packagers and commands dynamically, so no changes outside of the constants were required.

### Usage

**CLI:**
```
serverless client build --packager pnpm
```

**Via configuration:**
```
custom:
    buildClient:
        packager: pnpm
```

### Compatibility
- No breaking changes.
- Existing npm and yarn workflows are unaffected.
- Requires `pnpm` to be available in the runtime environment.